### PR TITLE
Allow include of openapi definition to pass validation

### DIFF
--- a/tests/functional/commands/validate/lib/models/explicit_http_api_minimum_include.yaml
+++ b/tests/functional/commands/validate/lib/models/explicit_http_api_minimum_include.yaml
@@ -1,0 +1,18 @@
+Resources:
+  Api:
+    Type: AWS::Serverless::HttpApi
+    Properties:
+      CorsConfiguration: True
+      DefinitionBody:
+        'Fn::Transform':
+          Name: AWS::Include
+          Parameters:
+            Location: tests/functional/commands/validate/lib/openapi/openapi.yaml
+  Function:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: index.handler
+      Runtime: python3.7
+      Events:
+        Api:
+          Type: HttpApi

--- a/tests/functional/commands/validate/lib/openapi/openapi.yaml
+++ b/tests/functional/commands/validate/lib/openapi/openapi.yaml
@@ -1,0 +1,6 @@
+---
+openapi: 3.0.0
+paths:
+  /test:
+    get:
+      summary: Get test

--- a/tests/unit/commands/validate/lib/openapi/notopenapi.yaml
+++ b/tests/unit/commands/validate/lib/openapi/notopenapi.yaml
@@ -1,0 +1,1 @@
+this is not yaml

--- a/tests/unit/commands/validate/lib/openapi/openapi.json
+++ b/tests/unit/commands/validate/lib/openapi/openapi.json
@@ -1,0 +1,18 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "title"
+  },
+  "paths": {
+    "/test": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "description"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/unit/commands/validate/lib/openapi/openapi.yaml
+++ b/tests/unit/commands/validate/lib/openapi/openapi.yaml
@@ -1,0 +1,6 @@
+---
+openapi: 3.0.0
+paths:
+  /test:
+    get:
+      summary: Get test

--- a/tests/unit/commands/validate/lib/test_sam_template_validator.py
+++ b/tests/unit/commands/validate/lib/test_sam_template_validator.py
@@ -7,7 +7,6 @@ from samtranslator.public.exceptions import InvalidDocumentException
 from samcli.commands.validate.lib.exceptions import InvalidSamDocumentException
 from samcli.commands.validate.lib.sam_template_validator import SamTemplateValidator
 
-
 class TestSamTemplateValidator(TestCase):
     @patch("samcli.commands.validate.lib.sam_template_validator.Session")
     @patch("samcli.commands.validate.lib.sam_template_validator.Translator")
@@ -408,42 +407,8 @@ class TestSamTemplateValidator(TestCase):
 
         template_resources = validator.sam_template.get("Resources")
         self.assertIn("DefinitionBody", template_resources.get("ServerlessApi").get("Properties"))
-        self.assertNotIn("openapi", template_resources.get("ServerlessApi").get("Properties").get("DefinitionBody"))
-        self.assertIn("Fn::Transform", template_resources.get("ServerlessApi").get("Properties").get("DefinitionBody"))
-
-
-    def test_DefinitionBody_not_replaced_if_not_valid_yaml(self):
-        template = {
-            "AWSTemplateFormatVersion": "2010-09-09",
-            "Transform": "AWS::Serverless-2016-10-31",
-            "Resources": {
-                "ServerlessApi": {
-                    "Type": "AWS::Serverless::HttpApi",
-                    "Properties": {
-                        "StageName": "Prod",
-                        "DefinitionBody": {
-                            "Fn::Transform": {
-                                "Name": "AWS::Include",
-                                "Parameters": {
-                                    "Location": "./tests/unit/commands/validate/lib/openapi/openapi.yaml"
-                                }
-                            }
-                        }
-                    },
-                }
-            },
-        }
-
-        managed_policy_mock = Mock()
-
-        validator = SamTemplateValidator(template, managed_policy_mock)
-
-        validator._replace_local_openapi()
-
-        template_resources = validator.sam_template.get("Resources")
-        self.assertIn("DefinitionBody", template_resources.get("ServerlessApi").get("Properties"))
-        self.assertNotIn("openapi", template_resources.get("ServerlessApi").get("Properties").get("DefinitionBody"))
-        self.assertIn("Fn::Transform", template_resources.get("ServerlessApi").get("Properties").get("DefinitionBody"))
+        self.assertNotIn("Fn::Transform", template_resources.get("ServerlessApi").get("Properties").get("DefinitionBody"))
+        self.assertIn("openapi", template_resources.get("ServerlessApi").get("Properties").get("DefinitionBody"))
 
     def test_DefinitionBody_not_replaced_if_not_include(self):
         template = {

--- a/tests/unit/commands/validate/lib/test_sam_template_validator.py
+++ b/tests/unit/commands/validate/lib/test_sam_template_validator.py
@@ -306,3 +306,171 @@ class TestSamTemplateValidator(TestCase):
 
         # check template
         self.assertEqual(validator.sam_template.get("Resources"), {})
+
+
+    def test_DefinitionBody_gets_replaced_in_api(self):
+        template = {
+            "AWSTemplateFormatVersion": "2010-09-09",
+            "Transform": "AWS::Serverless-2016-10-31",
+            "Resources": {
+                "ServerlessFunction": {
+                    "Type": "AWS::Serverless::Function"
+                },
+                "ServerlessApi": {
+                    "Type": "AWS::Serverless::Api",
+                    "Properties": {
+                        "StageName": "Prod",
+                        "DefinitionBody": {
+                            "Fn::Transform": {
+                                "Name": "AWS::Include",
+                                "Parameters": {
+                                    "Location": "./tests/unit/commands/validate/lib/openapi/openapi.yaml"
+                                }
+                            }
+                        }
+                    },
+                }
+            },
+        }
+
+        managed_policy_mock = Mock()
+
+        validator = SamTemplateValidator(template, managed_policy_mock)
+
+        validator._replace_local_openapi()
+
+        template_resources = validator.sam_template.get("Resources")
+        self.assertIn("DefinitionBody", template_resources.get("ServerlessApi").get("Properties"))
+        self.assertNotIn("Fn::Transform", template_resources.get("ServerlessApi").get("Properties").get("DefinitionBody"))
+        self.assertIn("openapi", template_resources.get("ServerlessApi").get("Properties").get("DefinitionBody"))
+
+    def test_DefinitionBody_not_replaced_if_file_not_found(self):
+        template = {
+            "AWSTemplateFormatVersion": "2010-09-09",
+            "Transform": "AWS::Serverless-2016-10-31",
+            "Resources": {
+                "ServerlessApi": {
+                    "Type": "AWS::Serverless::HttpApi",
+                    "Properties": {
+                        "StageName": "Prod",
+                        "DefinitionBody": {
+                            "Fn::Transform": {
+                                "Name": "AWS::Include",
+                                "Parameters": {
+                                    "Location": "./tests/unit/commands/validate/lib/openapi/notafile.yaml"
+                                }
+                            }
+                        }
+                    },
+                }
+            },
+        }
+
+        managed_policy_mock = Mock()
+
+        validator = SamTemplateValidator(template, managed_policy_mock)
+
+        validator._replace_local_openapi()
+
+        template_resources = validator.sam_template.get("Resources")
+        self.assertIn("DefinitionBody", template_resources.get("ServerlessApi").get("Properties"))
+        self.assertNotIn("openapi", template_resources.get("ServerlessApi").get("Properties").get("DefinitionBody"))
+        self.assertIn("Fn::Transform", template_resources.get("ServerlessApi").get("Properties").get("DefinitionBody"))
+
+
+    def test_DefinitionBody_gets_replaced_if_json(self):
+        template = {
+            "AWSTemplateFormatVersion": "2010-09-09",
+            "Transform": "AWS::Serverless-2016-10-31",
+            "Resources": {
+                "ServerlessApi": {
+                    "Type": "AWS::Serverless::HttpApi",
+                    "Properties": {
+                        "StageName": "Prod",
+                        "DefinitionBody": {
+                            "Fn::Transform": {
+                                "Name": "AWS::Include",
+                                "Parameters": {
+                                    "Location": "./tests/unit/commands/validate/lib/openapi/openapi.json"
+                                }
+                            }
+                        }
+                    },
+                }
+            },
+        }
+
+        managed_policy_mock = Mock()
+
+        validator = SamTemplateValidator(template, managed_policy_mock)
+
+        validator._replace_local_openapi()
+
+        template_resources = validator.sam_template.get("Resources")
+        self.assertIn("DefinitionBody", template_resources.get("ServerlessApi").get("Properties"))
+        self.assertNotIn("openapi", template_resources.get("ServerlessApi").get("Properties").get("DefinitionBody"))
+        self.assertIn("Fn::Transform", template_resources.get("ServerlessApi").get("Properties").get("DefinitionBody"))
+
+
+    def test_DefinitionBody_not_replaced_if_not_valid_yaml(self):
+        template = {
+            "AWSTemplateFormatVersion": "2010-09-09",
+            "Transform": "AWS::Serverless-2016-10-31",
+            "Resources": {
+                "ServerlessApi": {
+                    "Type": "AWS::Serverless::HttpApi",
+                    "Properties": {
+                        "StageName": "Prod",
+                        "DefinitionBody": {
+                            "Fn::Transform": {
+                                "Name": "AWS::Include",
+                                "Parameters": {
+                                    "Location": "./tests/unit/commands/validate/lib/openapi/openapi.yaml"
+                                }
+                            }
+                        }
+                    },
+                }
+            },
+        }
+
+        managed_policy_mock = Mock()
+
+        validator = SamTemplateValidator(template, managed_policy_mock)
+
+        validator._replace_local_openapi()
+
+        template_resources = validator.sam_template.get("Resources")
+        self.assertIn("DefinitionBody", template_resources.get("ServerlessApi").get("Properties"))
+        self.assertNotIn("openapi", template_resources.get("ServerlessApi").get("Properties").get("DefinitionBody"))
+        self.assertIn("Fn::Transform", template_resources.get("ServerlessApi").get("Properties").get("DefinitionBody"))
+
+    def test_DefinitionBody_not_replaced_if_not_include(self):
+        template = {
+            "AWSTemplateFormatVersion": "2010-09-09",
+            "Transform": "AWS::Serverless-2016-10-31",
+            "Resources": {
+                "ServerlessApi": {
+                    "Type": "AWS::Serverless::HttpApi",
+                    "Properties": {
+                        "StageName": "Prod",
+                        "DefinitionBody": {
+                            "Fn::Transform": {
+                                "Name": "AWS::NotInclude",
+                            }
+                        }
+                    },
+                }
+            },
+        }
+
+        managed_policy_mock = Mock()
+
+        validator = SamTemplateValidator(template, managed_policy_mock)
+
+        validator._replace_local_openapi()
+
+        template_resources = validator.sam_template.get("Resources")
+        self.assertIn("DefinitionBody", template_resources.get("ServerlessApi").get("Properties"))
+        self.assertNotIn("openapi", template_resources.get("ServerlessApi").get("Properties").get("DefinitionBody"))
+        self.assertIn("Fn::Transform", template_resources.get("ServerlessApi").get("Properties").get("DefinitionBody"))


### PR DESCRIPTION
Allow include of openapi definition to pass validation by loading into the main definition during validation.